### PR TITLE
feat(config): allow folder includes matching a pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,17 +199,20 @@ This rule includes all files within a given folder.
     "type": "folder",
     "folder": "Ownership/Alternate",
     "recursive": true,
+    "pattern":  "SomeRegex",
     "exclude": [
       "EUR Islands.txt"
     ]
 }
 ```
 
-There are two optional flags available for the folder rule:
+There are three optional flags available for the folder rule:
 
 - `recursive` (default: `false`) will cause the compiler to include all files in any subfolders
 contained within the main folder.
-- `exclude` will cause the compiler to ignore any files with a particular name.
+- `exclude` will cause the compiler to ignore any files with a particular name. Conversely, specifying `include`
+will only include files with a certain name.
+- `pattern` allows you to provide a regular expression, with only files matching the pattern being included.
 
 ## Comment Annotations
 

--- a/tests/CompilerTest/Config/ConfigIncludeLoaderTest.cs
+++ b/tests/CompilerTest/Config/ConfigIncludeLoaderTest.cs
@@ -17,8 +17,8 @@ namespace CompilerTest.Config
 
         public ConfigIncludeLoaderTest()
         {
-            this.fileLoader = new ConfigIncludeLoader();
-            this.includes = new ConfigInclusionRules();
+            fileLoader = new ConfigIncludeLoader();
+            includes = new ConfigInclusionRules();
         }
         
         [Theory]
@@ -41,10 +41,12 @@ namespace CompilerTest.Config
         [InlineData("_TestData/ConfigIncludeLoader/FilePathInvalid/config.json", "Invalid file path in section misc.regions - must be a string")]
         [InlineData("_TestData/ConfigIncludeLoader/ParentSectionNotArrayOrObject/config.json", "Invalid config section for enroute - must be an object or array of objects") ]
         [InlineData("_TestData/ConfigIncludeLoader/ParentSectionNotArrayOfObjects/config.json", "Invalid config section for enroute - must be an object or array of objects")]
+        [InlineData("_TestData/ConfigIncludeLoader/PatternNotAString/config.json", "Pattern invalid in section enroute.ownership - must be a regular expression string")]
+        [InlineData("_TestData/ConfigIncludeLoader/PatternInvalid/config.json", "Pattern invalid in section enroute.ownership - must be a regular expression string")]
         public void TestItThrowsExceptionOnBadData(string fileToLoad, string expectedMessage)
         {
             ConfigFileInvalidException exception = Assert.Throws<ConfigFileInvalidException>(
-                () => fileLoader.LoadConfig(this.includes, JObject.Parse(File.ReadAllText(fileToLoad)), fileToLoad)
+                () => fileLoader.LoadConfig(includes, JObject.Parse(File.ReadAllText(fileToLoad)), fileToLoad)
             );
             Assert.Equal(expectedMessage, exception.Message);
         }
@@ -58,18 +60,18 @@ namespace CompilerTest.Config
         public void TestItHandlesNoIncludes()
         {
             fileLoader.LoadConfig(
-                this.includes,
+                includes,
                 JObject.Parse(File.ReadAllText("_TestData/ConfigIncludeLoader/NoIncludes/config.json")),
                 "_TestData/ConfigIncludeLoader/NoIncludes/config.json"
             );
-            Assert.Empty(this.includes);
+            Assert.Empty(includes);
         }
 
         [Fact]
         public void TestItLoadsAConfigFile()
         {
             fileLoader.LoadConfig(
-                this.includes,
+                includes,
                 JObject.Parse(File.ReadAllText("_TestData/ConfigIncludeLoader/ValidConfig/config.json")),
                 "_TestData/ConfigIncludeLoader/ValidConfig/config.json"
             );
@@ -133,6 +135,7 @@ namespace CompilerTest.Config
             Assert.True(ownershipRule3.ExcludeList);
             Assert.Single(ownershipRule3.IncludeExcludeFiles);
             Assert.Equal("EUR Islands.txt", ownershipRule3.IncludeExcludeFiles[0]);
+            Assert.Equal(".*?", ownershipRule3.IncludePattern.ToString());
             Assert.Equal(new OutputGroup("enroute.ESE_OWNERSHIP", "Start enroute Ownership"), ownershipRule3.GetOutputGroup());
             
             // Misc regions

--- a/tests/CompilerTest/Input/FolderInclusionRuleTest.cs
+++ b/tests/CompilerTest/Input/FolderInclusionRuleTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Compiler.Input;
 using Compiler.Output;
 using Compiler.Exception;
@@ -44,9 +45,27 @@ namespace CompilerTest.Input
             IEnumerable<AbstractSectorDataFile> includeFiles = rule.GetFilesToInclude(fileFactory);
             List<AbstractSectorDataFile> files = includeFiles.ToList();
             Assert.Equal(3, files.Count);
-            Assert.Equal(this.GetFilePath("File1.txt"), files[0].FullPath);
-            Assert.Equal(this.GetFilePath("File2.txt"), files[1].FullPath);
-            Assert.Equal(this.GetFilePath("File3.txt"), files[2].FullPath);
+            Assert.Equal(GetFilePath("File1.txt"), files[0].FullPath);
+            Assert.Equal(GetFilePath("File2.txt"), files[1].FullPath);
+            Assert.Equal(GetFilePath("File3.txt"), files[2].FullPath);
+        }
+        
+        [Fact]
+        public void TestItLoadsFilesBasedOnARegularExpression()
+        {
+            FolderInclusionRule rule = new (
+                "_TestData/FolderInclusionRule",
+                false,
+                InputDataType.ESE_AGREEMENTS,
+                new OutputGroup("test"),
+                includePattern: new Regex("File[1|3].txt")
+            );
+
+            IEnumerable<AbstractSectorDataFile> includeFiles = rule.GetFilesToInclude(fileFactory);
+            List<AbstractSectorDataFile> files = includeFiles.ToList();
+            Assert.Equal(2, files.Count);
+            Assert.Equal(GetFilePath("File1.txt"), files[0].FullPath);
+            Assert.Equal(GetFilePath("File3.txt"), files[1].FullPath);
         }
         
         [Fact]
@@ -62,10 +81,10 @@ namespace CompilerTest.Input
             IEnumerable<AbstractSectorDataFile> includeFiles = rule.GetFilesToInclude(fileFactory);
             List<AbstractSectorDataFile> files = includeFiles.ToList();
             Assert.Equal(4, files.Count);
-            Assert.Equal(this.GetFilePath("File1.txt"), files[0].FullPath);
-            Assert.Equal(this.GetFilePath("File2.txt"), files[1].FullPath);
-            Assert.Equal(this.GetFilePath("File3.txt"), files[2].FullPath);
-            Assert.Equal(this.GetFilePath($"Level2{Path.DirectorySeparatorChar}File4.txt"), files[3].FullPath);
+            Assert.Equal(GetFilePath("File1.txt"), files[0].FullPath);
+            Assert.Equal(GetFilePath("File2.txt"), files[1].FullPath);
+            Assert.Equal(GetFilePath("File3.txt"), files[2].FullPath);
+            Assert.Equal(GetFilePath($"Level2{Path.DirectorySeparatorChar}File4.txt"), files[3].FullPath);
         }
         
         [Fact]
@@ -83,8 +102,8 @@ namespace CompilerTest.Input
             IEnumerable<AbstractSectorDataFile> includeFiles = rule.GetFilesToInclude(fileFactory);
             List<AbstractSectorDataFile> files = includeFiles.ToList();
             Assert.Equal(2, files.Count);
-            Assert.Equal(this.GetFilePath("File1.txt"), files[0].FullPath);
-            Assert.Equal(this.GetFilePath("File3.txt"), files[1].FullPath);
+            Assert.Equal(GetFilePath("File1.txt"), files[0].FullPath);
+            Assert.Equal(GetFilePath("File3.txt"), files[1].FullPath);
         }
 
         [Fact]
@@ -102,7 +121,7 @@ namespace CompilerTest.Input
             IEnumerable<AbstractSectorDataFile> includeFiles = rule.GetFilesToInclude(fileFactory);
             List<AbstractSectorDataFile> files = includeFiles.ToList();
             Assert.Single(files);
-            Assert.Equal(this.GetFilePath("File2.txt"), files[0].FullPath);
+            Assert.Equal(GetFilePath("File2.txt"), files[0].FullPath);
         }
 
         [Fact]

--- a/tests/CompilerTest/_TestData/ConfigIncludeLoader/PatternInvalid/config.json
+++ b/tests/CompilerTest/_TestData/ConfigIncludeLoader/PatternInvalid/config.json
@@ -1,0 +1,13 @@
+{
+  "includes": {
+    "enroute": {
+      "ownership": [
+        {
+          "type": "folder",
+          "folder": "test",
+          "pattern": "*"
+        }
+      ]
+    }
+  }
+}

--- a/tests/CompilerTest/_TestData/ConfigIncludeLoader/PatternNotAString/config.json
+++ b/tests/CompilerTest/_TestData/ConfigIncludeLoader/PatternNotAString/config.json
@@ -1,0 +1,13 @@
+{
+  "includes": {
+    "enroute": {
+      "ownership": [
+        {
+          "type": "folder",
+          "folder": "test",
+          "pattern": 123
+        }
+      ]
+    }
+  }
+}

--- a/tests/CompilerTest/_TestData/ConfigIncludeLoader/ValidConfig/config.json
+++ b/tests/CompilerTest/_TestData/ConfigIncludeLoader/ValidConfig/config.json
@@ -38,6 +38,7 @@
         {
           "type": "folder",
           "folder": "Ownership/Non-UK",
+          "pattern": ".*?",
           "exclude": [
             "EUR Islands.txt"
           ]


### PR DESCRIPTION
Allows you to specify that only file paths matching a pattern will be included